### PR TITLE
feat: add support for one service per mongos replica

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Database
 apiVersion: v2
-appVersion: 4.4.6
+appVersion: 4.5.0
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-service-per-replica.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-service-per-replica.yaml
@@ -1,0 +1,49 @@
+{{- if and .Values.mongos.useStatefulSet .Values.mongos.servicePerReplica.enabled -}}
+{{- range $i := until (.Values.mongos.replicas | int) }}
+{{- $copy := deepCopy $ -}}
+{{- $context := merge $copy (dict "index" $i) -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mongodb-sharded.serviceName" $ }}-{{ $i }}
+  labels: {{ include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: mongos
+  annotations: {{- include "common.tplvalues.render" (dict "value" $.Values.mongos.servicePerReplica.annotations "context" $context) | nindent 4 }}  
+spec:
+  type: {{ $.Values.mongos.servicePerReplica.type }}
+  {{- if and $.Values.mongos.servicePerReplica.loadBalancerIP (eq $.Values.mongos.servicePerReplica.type "LoadBalancer") }}
+  loadBalancerIP: {{ $.Values.mongos.servicePerReplica.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq $.Values.mongos.servicePerReplica.type "LoadBalancer") $.Values.mongos.servicePerReplica.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{ with $.Values.mongos.servicePerReplica.loadBalancerSourceRanges }}
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if and (eq $.Values.mongos.servicePerReplica.type "ClusterIP") $.Values.mongos.servicePerReplica.clusterIP }}
+  clusterIP: {{ $.Values.mongos.servicePerReplica.clusterIP }}
+  {{- end }}
+  ports:
+    - name: mongodb
+      port: {{ $.Values.mongos.servicePerReplica.port }}
+      targetPort: mongodb
+      {{- if $.Values.mongos.servicePerReplica.nodePort }}
+      nodePort: {{ $.Values.mongos.servicePerReplica.nodePort }}
+      {{- else if eq $.Values.mongos.servicePerReplica.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    {{- if $.Values.metrics.enabled }}
+    - name: metrics
+      port: 9216
+      targetPort: metrics
+    {{- end }}
+    {{- if $.Values.mongos.servicePerReplica.extraPorts }}
+      {{- include "common.tplvalues.render" (dict "value" $.Values.mongos.servicePerReplica.extraPorts "context" $context) | nindent 4 }}
+    {{- end }}
+  selector: {{ include "common.labels.matchLabels" $ | nindent 4 }}
+    app.kubernetes.io/component: mongos
+    statefulset.kubernetes.io/pod-name: {{ include "common.names.fullname" $ }}-mongos-{{ $i }}
+  sessionAffinity: {{ default "None" $.Values.mongos.servicePerReplica.sessionAffinity }}
+{{ end -}}
+{{- end -}}

--- a/bitnami/mongodb-sharded/values.yaml
+++ b/bitnami/mongodb-sharded/values.yaml
@@ -776,6 +776,59 @@ mongos:
   ## Use StatefulSet instead of Deployment
   ##
   useStatefulSet: false
+  ## When using a statefulset, you can enable one service per replica
+  ## This is useful when exposing the mongos through load balancers to make sure clients
+  ## connect to the same mongos and therefore can follow their cursors
+  ##
+  servicePerReplica:
+    enabled: false
+    ## Additional service annotations (evaluate as a template)
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    ##
+    annotations: {}
+    ## Service type
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+    ##
+    type: ClusterIP
+    ## External traffic policy
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+    ##
+    externalTrafficPolicy: Cluster
+    ## MongoDB(R) Service port and Container Port
+    ##
+    port: 27017
+    ## Set a fixed service ClusterIP address
+    ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#servicespec-v1-core
+    ##
+    clusterIP:
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    nodePort:
+
+    ## Specify the externalIP value ClusterIP service type.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
+    ##
+    externalIPs: []
+
+    ## Specify the loadBalancerIP value for LoadBalancer service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+    ##
+    loadBalancerIP:
+
+    ## Specify the loadBalancerSourceRanges value for LoadBalancer service types.
+    ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    loadBalancerSourceRanges: []
+    ## Extra ports to expose (normally used with the `sidecar` value)
+    ##
+    extraPorts: []
+    ## Specify the sessionAffinity setting for the service. Can be "None" or "ClientIP".
+    ## If "ClientIP", consecutive client requests will be directed to the same mongos Pod
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+    ##
+    sessionAffinity: None
+
   ## Pod disruption budget
   ##
   pdb:


### PR DESCRIPTION
This PR adds support for one service per mongos replica.

When using a statefulset, you can enable one service per replica.

This is useful when exposing the mongos through load balancers to make sure clients connect to the same mongos and therefore can follow their cursors.
